### PR TITLE
refactor route/queryParam changes, fix #472, #473 and race condition

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -113,13 +113,12 @@ import { LanguageSelectorComponent } from './core/language-selector.component';
     HttpClientModule,
     RouterModule.forRoot([
       {
-        path: ':city',
+        path: ':fountainIdOrAlias_cityIdOrAlias',
         component: RouterComponent,
       },
       {
         path: '',
-        redirectTo: '/ch-zh',
-        pathMatch: 'full',
+        component: RouterComponent,
       },
     ]),
     TranslateModule.forRoot({

--- a/src/app/core/config-based-parser.service.ts
+++ b/src/app/core/config-based-parser.service.ts
@@ -1,13 +1,13 @@
 import { Injectable } from '@angular/core';
 
-export interface Config<C = string> {
-  code: C;
-  aliases: string[];
+export interface Config<C> {
+  readonly code: C;
+  readonly aliases: readonly string[];
 }
 
 @Injectable()
 export class ConfigBasedParserService {
-  parse(value: string | undefined | null, configs: Config[]): string | undefined {
+  parse<T>(value: string | undefined | null, configs: readonly Config<T>[]): T | undefined {
     if (value === undefined || value === null) return undefined;
 
     const valueLower = value.toLowerCase();

--- a/src/app/core/language.service.ts
+++ b/src/app/core/language.service.ts
@@ -13,23 +13,11 @@ import { Translated } from '../locations';
 export const AVAILABLE_LANGS = ['en', 'de', 'fr', 'it', 'tr' /*, 'sr'*/] as const;
 export type Lang = typeof AVAILABLE_LANGS[number];
 
-// check that we cover all Lang which are defined in Translated and vice versa
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const _checkLangAndTranslatedInSync1: Lang = 'en' as keyof Translated<unknown>;
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const _checkLangAndTranslatedInSync2: keyof Translated<unknown> = 'en' as Lang;
-
-export function toLang(lang: string | undefined): Lang | undefined {
-  return isLang(lang) ? lang : undefined;
-}
-function isLang(lang: string | undefined): lang is Lang {
-  return lang !== undefined && AVAILABLE_LANGS.includes(lang as Lang);
-}
-
 const defaultLang: Lang = 'de';
+
 // the given order of the language codes here
 // determines the order in the language dropdown
-const languageConfig: Config<Lang>[] = [
+const internalLanguageConfig = [
   {
     code: 'en',
     aliases: ['english', 'anglais', 'englisch', 'en', 'e'],
@@ -54,7 +42,18 @@ const languageConfig: Config<Lang>[] = [
   //   code: 'sr',
   //   aliases: ['srpski', 'serbian', 'serbian', 'sr', 'srb'],
   // },
-];
+] as const;
+const languageConfig: readonly Config<Lang>[] = internalLanguageConfig;
+
+// check that we cover all Lang which are defined in Translated and vice versa
+const _checkLangAndTranslatedInSync1: Lang = 'en' as keyof Translated<unknown>;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const _checkLangAndTranslatedInSync2: keyof Translated<unknown> = _checkLangAndTranslatedInSync1;
+
+const _checkConfigAndAvailableLangInSync1: Pick<typeof internalLanguageConfig[number], 'code'> = { code: defaultLang };
+let _checkConfigAndAvailableLangInSync2 = _checkConfigAndAvailableLangInSync1.code;
+const _checkConfigAndAvailableLangInSync3: Lang = _checkConfigAndAvailableLangInSync2;
+_checkConfigAndAvailableLangInSync2 = _checkConfigAndAvailableLangInSync3 as Lang;
 
 @Injectable()
 export class LanguageService {
@@ -79,7 +78,7 @@ export class LanguageService {
   }
 
   changeLang(newLang: string): void {
-    const lang = toLang(this.configBasedParser.parse(newLang, languageConfig));
+    const lang = this.configBasedParser.parse(newLang, languageConfig);
     if (!lang) {
       throw new Error('given language is not supported: ' + newLang);
     } else {

--- a/src/app/fountain-aliases.ts
+++ b/src/app/fountain-aliases.ts
@@ -1,5 +1,5 @@
 // Define aliases for a particular fountain. as per https://github.com/water-fountains/datablue/issues/43
-export const aliases = [
+export const fountainAliases = [
   {
     // Rome.
     alias: 'trevi',
@@ -61,4 +61,4 @@ export const aliases = [
     alias: 'jetDeau',
     replace_alias: '60018172', //osm, wd also Q684661
   },
-];
+] as const;

--- a/src/app/map/map.config.ts
+++ b/src/app/map/map.config.ts
@@ -16,6 +16,7 @@ export class MapConfig {
     minZoom: 11,
     maxZoom: 20,
     zoomAfterDetail: 15,
+    //TODO @ralf.hauser not used, maxZoom is used in map.component.ts -> remove zoomToFountain?
     zoomToFountain: 17,
     style: 'mapbox://styles/water-fountains/cjkspc6ad1zh22sntedr63ivh',
     style_gray: 'mapbox://styles/water-fountains/cjdfuslg5ftqo2squxk76q8pl',

--- a/src/app/services/route-validator.service.ts
+++ b/src/app/services/route-validator.service.ts
@@ -9,16 +9,18 @@ import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { ParamMap } from '@angular/router';
 import _ from 'lodash';
-import { Observable, Subscription } from 'rxjs';
+import { Observable, of } from 'rxjs';
 import { LanguageService } from '../core/language.service';
 import { LayoutService } from '../core/layout.service';
-import { DataService, lookupAlias } from '../data.service';
+import { DataService, lookupFountainAlias } from '../data.service';
 import { FountainService } from '../fountain/fountain.service';
 import { City } from '../locations';
-import { cityConfigs, CityService, defaultCity } from '../city/city.service';
+import { CityService, defaultCity } from '../city/city.service';
 import { illegalState } from '../shared/illegalState';
-import { Database, FountainSelector, isDatabase } from '../types';
-import { getSingleNumberQueryParam, getSingleNumericQueryParam, getSingleStringQueryParam } from './utils';
+import { Database, FountainSelector, isDatabase, LngLat } from '../types';
+import { getSingleNumericParam, getSingleStringParam, isNumeric } from './utils';
+import { catchError, filter, first } from 'rxjs/operators';
+import { MapConfig } from '../map/map.config';
 
 export interface QueryParams {
   lang?: string;
@@ -43,307 +45,288 @@ export class RouteValidatorService {
   // Validates route names
 
   constructor(
-    //public router: Router,
-    //private route: ActivatedRoute,
     private http: HttpClient,
     private dataService: DataService,
     private languageService: LanguageService,
     private fountainService: FountainService,
     private cityService: CityService,
-    private layoutService: LayoutService
+    private layoutService: LayoutService,
+    private mapConfig: MapConfig
   ) {}
 
-  validateCity(value: string | null): City | null {
-    if (value == null) {
-      return null;
+  /**
+   * we have the following precedence rules:
+   * 1. if a valid fountain id (wikidata, osm or an alias) was defined in url => navigate to fountain, open detail, ignore id defined as queryparam, sharedLocation and/or city
+   * 2. if a valid fountain id (wikidata, osm or an alias) was defined in queryParam => navigate to fountain, open detail, ignore sharedLocation and/or city
+   * 3. if we find a valid shared location => navigate to the location, ignore city
+   * 4. if we find a valid city (code or alias) => navigate to the city
+   * 5. fallback to the default city which is ch-zh
+   *
+   * Which means we support the following urls:
+   * https://.../Q27229902 => wikidata id
+   * https://.../trevi => wikidata id alias
+   * https://.../60018172 => OSM id
+   * https://.../jetDeau => OSM id alias
+   * https://.../?loc=... => shared location
+   * https://.../ch-zh => city
+   * https://.../genève => city alias
+   * https://.../Q27229902?i=Q3429902 => wikidata id (id Q3429902 is ignored)
+   * https://.../Q27229902?loc=... => wikidata id (shared location ignored)
+   * https://.../?i=Q27229902&loc=... => wikidata id (shared location ignored)
+   * https://.../ch-zh?i=Q27229902?loc=... => wikidata id (shared location and city ignored)
+   * https://.../ch-zh?loc=... => shared location (city ignored)
+   */
+  handleUrlChange(routeParam: ParamMap, queryParam: ParamMap): Observable<boolean> {
+    const fountainIdOrAlias_cityIdOrAlias = getSingleStringParam(
+      routeParam,
+      'fountainIdOrAlias_cityIdOrAlias',
+      /* isOptional= */ true
+    );
+
+    // incorporates the side effect to change
+    this.detectLanguageChange(queryParam);
+
+    return this.navigateWithFirstValidMechanism(
+      // fountain id or alias in routeParam
+      this.navigateToFountain(fountainIdOrAlias_cityIdOrAlias),
+      () => {
+        const id = getSingleStringParam(queryParam, 'i', /* isOptional= */ true);
+        return this.navigateToFountain(id);
+      },
+      () => {
+        const loc = getSingleStringParam(queryParam, 'loc', /* isOptional= */ true);
+        return this.navigateToSharedLocation(loc);
+      },
+      () => this.navigateToCity(fountainIdOrAlias_cityIdOrAlias),
+      () => this.navigateToCity(defaultCity)
+    );
+  }
+
+  private navigateWithFirstValidMechanism(
+    firstMechanism: Observable<boolean>,
+    ...others: (() => Observable<boolean>)[]
+  ): Observable<boolean> {
+    return others.reduce(
+      (previousMechanism, nextMechanism) =>
+        previousMechanism
+          .pipe(filter(previousMechanismMatched => previousMechanismMatched === false))
+          .switchMap(_ => nextMechanism()),
+      /* initialValue = */ firstMechanism
+    );
+  }
+
+  private navigateToFountain(maybeIdOrAlias: string | undefined): Observable<boolean> {
+    if (maybeIdOrAlias !== undefined) {
+      const id = lookupFountainAlias(maybeIdOrAlias) ?? maybeIdOrAlias;
+      return this.getLngLatOfFountain(id).map(data => {
+        if (data !== undefined) {
+          const { lngLat, database, updateId } = data;
+          const city = this.getCityByLngLat(lngLat);
+          if (city !== undefined) {
+            //TODO @ralf.hauser this function currently depends on that a fountain is in a city
+            this.layoutService.flyToCity(city);
+            this.updateFromId(database, updateId);
+          }
+          return true;
+        } else {
+          return false;
+        }
+      });
     } else {
-      let newCity: City = defaultCity;
-      // see if there is a match among aliases
-
-      if (value.trim().length > 0) {
-        cityConfigs.forEach((config, i) => {
-          // find matching
-          if (config.aliases.includes(value.toLocaleLowerCase())) {
-            newCity = config.code;
-            console.log(
-              i + " location-alias '" + newCity + "' matched for '" + value + "' " + new Date().toISOString()
-            );
-            return;
-          }
-        });
-      }
-
-      if (newCity) {
-        this.cityService.city.subscribeOnce(city => {
-          // update if different from current state
-          if (newCity !== city) {
-            console.log('fly to city ' + newCity + "' based on value '" + value + "' " + new Date().toISOString());
-            this.layoutService.flyToCity(newCity);
-          }
-        });
-      } else {
-        console.log('illegal city code ' + value + ' ' + new Date().toISOString());
-      }
-
-      return newCity;
+      return of(false);
     }
   }
 
-  //TODO @ralf.hauser, this code is most likely broken. This function always returns null (because the promise is not returned)
-  //TODO @ralf.hauser this function looks a lot like getOsmNodeByWikiDataQnumber, I recommend to split up and reuse
-  getOsmNodeByNumber(cityOrId: string, type = 'node'): null {
-    // attempt to fetch OSM node
-    const url = `https://overpass-api.de/api/interpreter?data=[out:json];${type}(${cityOrId});out center;`;
-    this.http.get(url).subscribe(
-      data => {
-        let fountain = null;
-        if (type === 'node') {
-          fountain = _.get(data, ['elements', 0]);
-        } else if (type === 'way') {
-          fountain = _.get(data, ['elements', 0, 'center']);
+  private getLngLatOfFountain(id: string): Observable<LngLatUpdate | undefined> {
+    if (isWikidataId(id)) {
+      return this.getLngLatOfWikidataFountain(id);
+    } else if (isOsmId(id)) {
+      return this.getLngLatOfOsmFountain(id);
+    } else {
+      return of(undefined);
+    }
+  }
+
+  private getLngLatOfWikidataFountain(id: string): Observable<LngLatUpdate | undefined> {
+    const url = `https://www.wikidata.org/w/api.php?action=wbgetentities&ids=${id}&format=json&origin=*`;
+    return this.http
+      .get(url)
+      .map<LngLatUpdate | undefined>(data => {
+        const coords = _.get(data, ['entities', id, 'claims', 'P625', 0, 'mainsnak', 'datavalue', 'value']);
+        if (coords) {
+          return {
+            lngLat: LngLat(coords['longitude'], coords['latitude']),
+            database: 'wikidata',
+            updateId: id,
+          };
         } else {
-          console.log('getOsmNodeByNumber: Don\'t know how to handle type "' + type + '" ' + new Date().toISOString());
+          console.log(
+            'validateWikidata: Wikidata query returned no elements with coordinates for "' +
+              id +
+              '" ' +
+              new Date().toISOString()
+          );
+          return undefined;
         }
-        if (fountain) {
-          this.checkCoordinatesInCity(
-            fountain['lat'],
-            fountain['lon'],
-            'getOsmNodeByNumber by ' + type + ' ' + cityOrId
-          )
-            .then(cityCode => {
-              // if a city was found, then broadcast the change
-              this.layoutService.flyToCity(cityCode);
-              this.updateFromId('osm', type + '/' + cityOrId);
-              return cityCode;
-            })
-            .catch(message => {
-              console.log(message + ' ' + new Date().toISOString());
-              return null;
-            });
+      })
+      .pipe(
+        catchError(error => {
+          console.log(
+            'validateWikidata: Error when looking up Wikidata element: ' +
+              JSON.stringify(error, null, 2) +
+              ' - "' +
+              id +
+              '" ' +
+              new Date().toISOString()
+          );
+          return of(undefined);
+        })
+      );
+  }
+
+  private getLngLatOfOsmFountain(id: string): Observable<LngLatUpdate | undefined> {
+    // TODO @ralf.hauser I don't have OSM know-how. If it is possible that a node id has the same number as a way id
+    // then the node always takes precedence with this implementation. We would need to prefix the id (additionally)
+    // in order to support both
+    return this.getLngLatOfOsmFountainByType(id, 'node').switchMap(data =>
+      data ? of(data) : this.getLngLatOfOsmFountainByType(id, 'way')
+    );
+  }
+
+  private getLngLatOfOsmFountainByType(id: string, type: 'node' | 'way'): Observable<LngLatUpdate | undefined> {
+    const url = `https://overpass-api.de/api/interpreter?data=[out:json];${type}(${id});out center;`;
+    return this.http
+      .get(url)
+      .map<LngLatUpdate | undefined>(data => {
+        const lngLat = this.extractLngLatFromOsmData(type, data);
+        if (lngLat) {
+          return { lngLat: lngLat, database: 'osm', updateId: type + '/' + id };
         } else {
           console.log(
             'getOsmNodeByNumber: OSM query returned no elements for url "' + url + '" ' + new Date().toISOString()
           );
-          return null;
+          return undefined;
         }
-        return null;
-      },
-      error => {
-        console.log(
-          'Error when looking up OSM element: ' + JSON.stringify(error, null, 2) + ' ' + new Date().toISOString()
-        );
-        return null;
-      }
-    );
-    return null;
-  }
-
-  //TODO @ralf.hauser, this code is most likely broken. This function returns a subscription where the calle expects a Promise
-  //TODO @ralf.hauser this function looks a lot like getOsmNodeByNumber, I recommend to split up and reuse
-  getOsmNodeByWikiDataQnumber(qNumb: string, type = 'node', amenity = 'fountain'): Subscription {
-    // attempt to fetch OSM node
-    //as per https://github.com/water-fountains/proximap/issues/244#issuecomment-578483473, https://overpass-turbo.eu/s/Q62
-    //DaveF suggested:  If you don't know if the entity was mapped as a single point, swap node for nwr (Node, Way, Relation) type='nrw' could be an alternative
-    const url = `https://overpass-api.de/api/interpreter?data=[out:json];${type}[amenity=${amenity}][wikidata=${qNumb}];out%20center;`; //
-    console.log('getOsmNodeByWikiDataQnumber: about to "' + url + '" ' + new Date().toISOString());
-    const getOsmNodeByWikiDataQnumberGet = this.http.get(url).subscribe(
-      data => {
-        let fountain = null; //test with http://localhost:4200/Q83630092 and http://localhost:4200/Q94066483
-        if (type === 'node') {
-          fountain = _.get(data, ['elements', 0]);
-        } else if (type === 'way') {
-          fountain = _.get(data, ['elements', 0, 'center']);
-        } else {
+      })
+      .pipe(
+        catchError(error => {
           console.log(
-            'getOsmNodeByWikiDataQnumber: Don\'t know how to handle type "' + type + '" ' + new Date().toISOString()
+            `Error when looking up OSM element via url ${url}: ${JSON.stringify(
+              error,
+              null,
+              2
+            )} ${new Date().toISOString()}`
           );
-        }
-        if (fountain) {
-          this.checkCoordinatesInCity(
-            fountain['lat'],
-            fountain['lon'],
-            'getOsmNodeByWikiDataQnumber ' + qNumb + ' ' + type + ' ' + amenity
-          )
-            .then(cityCode => {
-              // if a city was found, then broadcast the change
-              this.layoutService.flyToCity(cityCode);
-              this.updateFromId('wikidata', type + '/' + qNumb);
-              console.log(
-                'getOsmNodeByWikiDataQnumber: for "' +
-                  qNumb +
-                  '" found city "' +
-                  cityCode +
-                  '" ' +
-                  new Date().toISOString()
-              );
-              return cityCode;
-            })
-            .catch(message => {
-              console.log(message + ' ' + new Date().toISOString());
-              return null;
-            });
-        } else {
-          console.log(
-            'getOsmNodeByWikiDataQnumber: OSM query returned no elements for url "' +
-              url +
-              '" ' +
-              new Date().toISOString()
-          );
-          return null;
-        }
-        return null;
-      },
-      error => {
-        console.log(
-          'Error when looking up OSM element: ' + JSON.stringify(error, null, 2) + ' ' + new Date().toISOString()
-        );
-        return null;
-      }
-    );
-    //getOsmNodeByWikiDataQnumberGet.caller = "getOsmNodeByWikiDataQnumberGet:"+qNumb; //seems not to work with TypeScript: Property 'caller' does not exist on type 'Subscription'.
-    return getOsmNodeByWikiDataQnumberGet;
+          return of(undefined);
+        })
+      );
   }
 
-  /**
-   * Check if a query to OSM with the given string gives a fountain that is in one of the valid cities
-   * @param cityOrId query parameter that may be an OSM id
-   * @param type either "node" or "way"
-   */
-  validateOsm(cityOrId: string, type = 'node'): Promise<null> {
-    return new Promise((resolve, reject) => {
-      // Check is exist filter text in aliases data.
-      const alias = lookupAlias(cityOrId);
-      if (null != alias && 0 < alias.trim().length) {
-        cityOrId = alias;
-      }
-      if (isNaN(+cityOrId)) {
-        //check if number
-        reject('string ' + cityOrId + ' does not match osm node format - ' + type);
-      } else {
-        const cityCode = this.getOsmNodeByNumber(cityOrId, type);
-        if (null == cityCode) {
-          reject();
-        }
-        resolve(cityCode);
-      }
-    });
-  }
-
-  /**
-   * Check if a query to Wikidata with the given string gives a fountain that is in one of the valid cities
-   * @param cityOrId query parameter that may be an Wikidata id
-   */
-  validateWikidata(cityOrId: string): Promise<string> {
-    return new Promise((resolve, reject) => {
-      // Check is exist filter text in aliases data.
-      const alias = lookupAlias(cityOrId);
-      if (null != alias && 0 < alias.trim().length) {
-        cityOrId = alias;
-      }
-      if (null == cityOrId || 0 == cityOrId.trim().length || cityOrId[0] !== 'Q' || isNaN(+cityOrId.slice(1))) {
-        reject('string "' + cityOrId + '" does not match wikidata format');
-      } else {
-        console.log('attempt to fetch Wikidata node "' + cityOrId + '" ' + new Date().toISOString());
-        // TODO first check the fountains of the currently loaded city
-        // this code will never be executed because currFtns is fix set to null
-        // const currFtns = null; // this.dataService.fountainsAll();
-        // if (null != currFtns) {
-        //   for (const ftn of currFtns.features) {
-        //     if (ftn['properties']['id_wikidata'] !== null) {
-        //       if (ftn['properties']['id_wikidata'] === cityOrId) {
-        //         // TODO @ralf.hauser cityOrId is not a proper FountainSelctor. Check if the selector is used somewhere, otherwise we could remove it entirely
-        //         resolve(cityOrId);
-        //       }
-        //     }
-        //   }
-        // }
-        const url = `https://www.wikidata.org/w/api.php?action=wbgetentities&ids=${cityOrId}&format=json&origin=*`;
-        this.http.get(url).subscribe(
-          data => {
-            const coords = _.get(data, ['entities', cityOrId, 'claims', 'P625', 0, 'mainsnak', 'datavalue', 'value']);
-            //this is also an inefficient query like EuroPuddle Artist
-            if (!coords) {
-              const osmNodeByWikiDataQnumberPromises = [];
-              osmNodeByWikiDataQnumberPromises.push(this.getOsmNodeByWikiDataQnumber(cityOrId, 'node', 'fountain'));
-              Promise.all(osmNodeByWikiDataQnumberPromises).then(() => {
-                //test with http://localhost:4200/Q83630092 ch-zh Klusdörfli Sandstein BL
-                const osmNodeByWikiDataQnumberPromisesDrinking = [];
-                osmNodeByWikiDataQnumberPromisesDrinking.push(
-                  this.getOsmNodeByWikiDataQnumber(cityOrId, 'node', 'drinking_water')
-                );
-                Promise.all(osmNodeByWikiDataQnumberPromisesDrinking).then(rd => {
-                  //test with http://localhost:4200/Q94066483 ch-zh Brunnen röm. kath Kirche Zollikon
-                  if (null != rd) {
-                    //resolve(rd);
-                  }
-                });
-              });
-            }
-            if (coords) {
-              this.checkCoordinatesInCity(coords['latitude'], coords['longitude'], 'validateWikidata ' + cityOrId)
-                .then(cityCode => {
-                  // if a city was found, then broadcast the change
-                  this.layoutService.flyToCity(cityCode);
-                  this.updateFromId('wikidata', cityOrId);
-                  resolve(cityCode);
-                })
-                .catch(message => {
-                  console.log(message + ' - "' + cityOrId + '"');
-                  reject();
-                });
-            } else {
-              console.log(
-                'validateWikidata: Wikidata query returned no elements with coordinates for "' +
-                  cityOrId +
-                  '" ' +
-                  new Date().toISOString()
-              );
-              reject();
-            }
-          },
-          error => {
-            console.log(
-              'validateWikidata: Error when looking up Wikidata element: ' +
-                JSON.stringify(error, null, 2) +
-                ' - "' +
-                cityOrId +
-                '" ' +
-                new Date().toISOString()
-            );
-            reject();
-          }
-        );
-      }
-    });
+  private extractLngLatFromOsmData(type: string, data: Object): LngLat | undefined {
+    let fountain = null;
+    if (type === 'node') {
+      fountain = _.get(data, ['elements', 0]);
+    } else if (type === 'way') {
+      fountain = _.get(data, ['elements', 0, 'center']);
+    }
+    return fountain ? LngLat(fountain['lon'], fountain['lat']) : undefined;
   }
 
   // Made for https://github.com/water-fountains/proximap/issues/244 to check if coords in any city
-  checkCoordinatesInCity(lat: number, lng: number, debug = ''): Promise<City> {
-    return new Promise((resolve, reject) => {
-      // loop through locations and see if coords are in a city
-      const [locationsCollection, cities] = this.dataService.getLocationMetadata();
+  private getCityByLngLat(lngLat: LngLat): City | undefined {
+    const [locationsCollection, cities] = this.dataService.getLocationMetadata();
 
-      const city = cities.find(city => {
-        const boundingBox = locationsCollection[city].bounding_box;
-        return (
-          lat > boundingBox.latMin &&
-          lat < boundingBox.latMax && //
-          lng > boundingBox.lngMin &&
-          lng < boundingBox.lngMax
-        );
-      });
-      if (city) {
-        //if cities have box overlaps, then only the first one is found
-        resolve(city);
-      } else {
-        reject(
-          `None of the ${cities.length} supported locations have those coordinates lat: ${lat},  lon: ${lng} - ` + debug
-        );
-      }
+    return cities.find(city => {
+      const boundingBox = locationsCollection[city].bounding_box;
+      return (
+        lngLat.lat > boundingBox.latMin &&
+        lngLat.lat < boundingBox.latMax && //
+        lngLat.lng > boundingBox.lngMin &&
+        lngLat.lng < boundingBox.lngMax
+      );
     });
   }
 
-  getQueryParams(): Observable<QueryParams> {
+  private updateFromId(database: Database, id: string): void {
+    const fountainSelector: FountainSelector = {
+      queryType: 'byId',
+      idval: id,
+      database: database,
+    };
+    console.log('updateFromId: database "' + database + '", id "' + id + '" ' + new Date().toISOString());
+    this.dataService.selectFountainBySelector(fountainSelector);
+  }
+
+  private navigateToSharedLocation(maybLocAsString: string | undefined): Observable<boolean> {
+    const locArr = maybLocAsString !== undefined ? maybLocAsString.split(',') : [];
+    if ((locArr.length === 2 || locArr.length === 3) && isNumeric(locArr[0]) && isNumeric(locArr[1])) {
+      const lat = Number(locArr[0]);
+      const lng = Number(locArr[1]);
+      // TODO @robstoll implement sharedLocation here
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const _sharedLocation = { lngLat: LngLat(lng, lat), zoom: this.parseZoomOrDefault(locArr) };
+      return of(false);
+    } else {
+      return of(false);
+    }
+  }
+
+  private navigateToCity(maybeCity: string | undefined): Observable<boolean> {
+    const newCity = this.cityService.parse(maybeCity);
+    console.log("cityCode '" + newCity + "' cityOrId  '" + maybeCity + "' " + new Date().toISOString()); //todo show what came as parameters: https://angular.io/api/router/ParamMap  for '"+paramMap.params+"'
+
+    if (newCity !== undefined) {
+      // we are only interested in the current value at the time we navigate, thus pipe(first)
+      // if we don't use it we would get the update flyToCity produces (due to the subject change to newCity)
+      // and since city is then alwas == newCity we would return false even though we navigated beforehand
+      return this.cityService.city.pipe(first()).map(city => {
+        // update if different from current state
+        if (newCity !== city) {
+          console.log('fly to city ' + newCity + "' based on value '" + city + "' " + new Date().toISOString());
+          this.layoutService.flyToCity(newCity);
+        }
+        // regardless if we have to fly to the city or if we are already in the city
+        // we return true as we do no longer need to navigate
+        return true;
+      });
+    } else {
+      return of(false);
+    }
+  }
+
+  private parseZoomOrDefault(arr: string[]): number {
+    let zoom = this.mapConfig.map.zoom;
+    const arg2 = arr[2];
+    if (arg2 !== undefined) {
+      const tmpZoom = parseInt(arg2, 10);
+      if (!isNaN(tmpZoom)) {
+        if (tmpZoom > this.mapConfig.map.maxZoom) {
+          zoom = this.mapConfig.map.maxZoom;
+        } else if (tmpZoom < this.mapConfig.map.minZoom) {
+          zoom = this.mapConfig.map.minZoom;
+        } else {
+          zoom = tmpZoom;
+        }
+      }
+    }
+    return zoom;
+  }
+
+  private detectLanguageChange(queryParams: ParamMap) {
+    // validate lang
+    const lang =
+      getSingleStringParam(queryParams, 'lang', /*isOptional = */ true) ||
+      getSingleStringParam(queryParams, 'l', /*isOptional = */ true);
+    if (lang !== undefined) {
+      try {
+        this.languageService.changeLang(lang);
+      } catch (e: unknown) {
+        // just ignore if the language is not supported
+      }
+    }
+  }
+
+  getShortenedQueryParams(): Observable<QueryParams> {
     return this.fountainService.fountainSelector.map(fountainSelector => {
       // Get query parameter values from app state. use short query params by default for #159
       const queryParams: QueryParams = {
@@ -363,85 +346,18 @@ export class RouteValidatorService {
       return queryParams;
     });
   }
+}
 
-  updateFromId(database: Database, id: string): void {
-    const fountainSelector: FountainSelector = {
-      queryType: 'byId',
-      idval: id,
-      database: database,
-    };
-    console.log('updateFromId: database "' + database + '", id "' + id + '" ' + new Date().toISOString());
-    this.dataService.selectFountainBySelector(fountainSelector);
-  }
+function isWikidataId(id: string): boolean {
+  return id.length > 1 && id[0] === 'Q' && isNumeric(id.slice(1));
+}
 
-  updateFromRouteParams(paramsMap: ParamMap): void {
-    // update application state (indirectly) from url route params
+function isOsmId(id: string): boolean {
+  return isNumeric(id);
+}
 
-    // validate lang
-    const lang =
-      getSingleStringQueryParam(paramsMap, 'lang', /*isOptional = */ true) ||
-      getSingleStringQueryParam(paramsMap, 'l', /*isOptional = */ true);
-    if (lang !== undefined) {
-      try {
-        this.languageService.changeLang(lang);
-      } catch (e: unknown) {
-        // just ignore if the language is not supported
-      }
-    }
-    // this.validate('lang', lang, true);
-
-    // create valid fountain selector from query params
-    const fountainSelector: FountainSelector = {
-      queryType: 'byId',
-    };
-
-    // See what values are available
-    const id =
-      getSingleStringQueryParam(paramsMap, 'i', /*isOptional = */ true) ||
-      getSingleStringQueryParam(paramsMap, 'idval', /*isOptional = */ true);
-    const lat = getSingleNumericQueryParam(paramsMap, 'lat', /*isOptional = */ true);
-    const lng = getSingleNumericQueryParam(paramsMap, 'lng', /*isOptional = */ true);
-    // if id is in params, use to locate fountain
-    if (id !== undefined) {
-      fountainSelector.queryType = 'byId';
-      fountainSelector.idval = id;
-      // determine the database from the id if database not already provided
-      //TODO @ralf.hauser this looks very smelly, is it correct, that the query param database is only used as trigger. because database defined independend of it afterwards.
-      const databaseQueryString = paramsMap.get('database');
-      let database: Database;
-      if (databaseQueryString === null) {
-        if (id[0] !== undefined && id[0].toLowerCase() == 'q') {
-          database = 'wikidata';
-        } else if (['node', 'way'].includes(id.split('/')[0] ?? 'no-slash-in-id-cannot-be-node-or-way')) {
-          database = 'osm';
-        } else {
-          database = 'operator';
-        }
-      } else if (isDatabase(databaseQueryString)) {
-        database = databaseQueryString;
-      } else {
-        illegalState('invalid database given: ' + databaseQueryString);
-      }
-      fountainSelector.database = database;
-      // otherwise, check if coordinates are specified and if so, use those
-    } else if (lat !== undefined && lng !== undefined) {
-      fountainSelector.queryType = 'byCoords';
-      fountainSelector.lat = lat;
-      fountainSelector.lng = lng;
-
-      // it seems that it is not possible to select a fountain with the given information.
-      // todo: Show an error message
-    } else {
-      return;
-    }
-
-    // TODO @ralf.hauser, IMO it is always a smell if a service subscribes. A service should map and let the caller decide
-    // what happens next
-    this.fountainService.fountainSelector.subscribeOnce(currentFountainSelector => {
-      // if the query param fountain doesn't match the state fountain, select the query fountain
-      if (JSON.stringify(fountainSelector) !== JSON.stringify(currentFountainSelector)) {
-        this.dataService.selectFountainBySelector(fountainSelector);
-      }
-    });
-  }
+interface LngLatUpdate {
+  lngLat: LngLat;
+  database: Database;
+  updateId: string;
 }

--- a/src/app/services/utils.ts
+++ b/src/app/services/utils.ts
@@ -1,22 +1,14 @@
 import { ParamMap } from '@angular/router';
 
-export function getSingleStringQueryParam(paramMap: ParamMap, paramName: string): string;
-export function getSingleStringQueryParam(paramMap: ParamMap, paramName: string, isOptional: true): string | undefined;
-export function getSingleStringQueryParam(
-  paramMap: ParamMap,
-  paramName: string,
-  isOptional = false
-): string | undefined {
+export function getSingleStringParam(paramMap: ParamMap, paramName: string): string;
+export function getSingleStringParam(paramMap: ParamMap, paramName: string, isOptional: true): string | undefined;
+export function getSingleStringParam(paramMap: ParamMap, paramName: string, isOptional = false): string | undefined {
   return getSingleQueryParamTypeOfCheck(paramMap, paramName, isOptional, 'string');
 }
 
-export function getSingleNumericQueryParam(paramMap: ParamMap, paramName: string): number;
-export function getSingleNumericQueryParam(paramMap: ParamMap, paramName: string, isOptional: true): number | undefined;
-export function getSingleNumericQueryParam(
-  paramMap: ParamMap,
-  paramName: string,
-  isOptional = false
-): number | undefined {
+export function getSingleNumericParam(paramMap: ParamMap, paramName: string): number;
+export function getSingleNumericParam(paramMap: ParamMap, paramName: string, isOptional: true): number | undefined;
+export function getSingleNumericParam(paramMap: ParamMap, paramName: string, isOptional = false): number | undefined {
   return getSingleQueryParam(
     paramMap,
     paramName,
@@ -27,7 +19,7 @@ export function getSingleNumericQueryParam(
   );
 }
 
-function isNumeric(v: string | undefined): boolean {
+export function isNumeric(v: string | undefined): boolean {
   if (typeof v === 'number') return true;
   if (typeof v !== 'string') return false;
   return (
@@ -37,27 +29,15 @@ function isNumeric(v: string | undefined): boolean {
   );
 }
 
-export function getSingleNumberQueryParam(paramMap: ParamMap, paramName: string): number;
-export function getSingleNumberQueryParam(paramMap: ParamMap, paramName: string, isOptional: true): number | undefined;
-export function getSingleNumberQueryParam(
-  paramMap: ParamMap,
-  paramName: string,
-  isOptional = false
-): number | undefined {
+export function getSingleNumberParam(paramMap: ParamMap, paramName: string): number;
+export function getSingleNumberParam(paramMap: ParamMap, paramName: string, isOptional: true): number | undefined;
+export function getSingleNumberParam(paramMap: ParamMap, paramName: string, isOptional = false): number | undefined {
   return getSingleQueryParamTypeOfCheck(paramMap, paramName, isOptional, 'numberic');
 }
 
-export function getSingleBooleanQueryParam(paramMap: ParamMap, paramName: string): boolean;
-export function getSingleBooleanQueryParam(
-  paramMap: ParamMap,
-  paramName: string,
-  isOptional: true
-): boolean | undefined;
-export function getSingleBooleanQueryParam(
-  paramMap: ParamMap,
-  paramName: string,
-  isOptional = false
-): boolean | undefined {
+export function getSingleBooleanParam(paramMap: ParamMap, paramName: string): boolean;
+export function getSingleBooleanParam(paramMap: ParamMap, paramName: string, isOptional: true): boolean | undefined;
+export function getSingleBooleanParam(paramMap: ParamMap, paramName: string, isOptional = false): boolean | undefined {
   return getSingleQueryParamTypeOfCheck(paramMap, paramName, isOptional, 'boolean');
 }
 

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -9,6 +9,7 @@ import { HttpResponseBase } from '@angular/common/http';
 import { Feature, FeatureCollection, Geometry, Point } from 'geojson';
 import { FountainPropertiesMeta, NamedSources, SourceConfig } from './fountain_properties';
 import { Translated } from './locations';
+import { illegalState } from './shared/illegalState';
 
 export interface PropertyMetadata {
   essential: boolean;
@@ -140,9 +141,22 @@ export type FountainCollection<G extends Geometry = DefaultFountainGeometry> = F
   FountainPropertyCollection<Record<string, unknown>>
 >;
 
-export type LngLat = [number, number];
-
+export interface LngLat {
+  lng: number;
+  lat: number;
+}
+export function LngLat(lng: number, lat: number): LngLat {
+  if (lng >= -180 && lng <= 180 && lat >= -90 && lat <= 90) {
+    return { lng: lng, lat: lat };
+  } else {
+    illegalState('lng or lat are out of range', lng, lat);
+  }
+}
 export type Bounds = [LngLat, LngLat];
+export interface SharedLocation {
+  lngLat: LngLat;
+  zoom: number;
+}
 
 // TODO it would make more sense to move common types to an own library which is consumed by both, datablue and proximap
 // if you change something here, then you need to change it in proximap as well


### PR DESCRIPTION
implement a nice and clean url change handler where it is clear at a
glance which priorities are set

moreover:
- introduce an object for LngLat instead of [number, number] which
  requires index access
- reuse ConfigBasedParserService in CityService instead of own parsing
  logic in route-validator.service.ts
- generify ConfigBasedParserService.parse and simplify logic for
  language parsing (remove toLang and isLang)
- rename getSingleStringQueryParam to getSingleStringParam as it can
  also be used for routeParams

cleanups:
- split up selectFountainBySelector into smaller methods
- remove Promise for DataService.getLocationBounds as the data is static
- do not use `!` for MapComponent properties, use `| undefined` instead
-