### PR TITLE
#491 use map.center for loc as jumpTo requires it

### DIFF
--- a/src/app/services/routing.service.ts
+++ b/src/app/services/routing.service.ts
@@ -106,9 +106,9 @@ export class RoutingService {
           const { lngLat, database, updateId } = data;
           const city = this.getCityByLngLat(lngLat);
           if (city !== undefined) {
-            this.updateFromId(database, updateId);
             //TODO @ralf.hauser this function currently depends on that a fountain is in a city
             this.layoutService.flyToCity(city);
+            this.updateFromId(database, updateId);
           }
           return true;
         } else {


### PR DESCRIPTION
moreover:
- also use the first load strategy for ?loc= (move into inner
  actOnFirstLoad function)
- don't navigate in router.component.ts if neither the city nor the
  query params have changed