### PR TITLE
#490 check for programmatic routing

### DIFF
--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -288,6 +288,8 @@ export interface FountainProperty {
   source_name?: string;
   issues?: DataIssue[];
 }
+// TODO it would make more sense to move common types to an own library which is consumed by both, datablue and proximap
+// if you change something here, then you need to change it in datablue as well
 export type Database = SourceType;
 
 export interface FountainSelector {


### PR DESCRIPTION
I figured it would be enough to have a guard in MapService to not
emit a new state in case it is the same as the current. Yet, I was
proven to be wrong and it definitely better to not process a
programmatic route change twice.