### PR TITLE
#419 load by bounding box

### DIFF
--- a/src/app/detail/detail.component.ts
+++ b/src/app/detail/detail.component.ts
@@ -112,16 +112,12 @@ export class DetailComponent implements OnInit {
                     cats = catArr.value;
                   }
                   if (
-                    fProps['id_wikidata'] !== null &&
+                    fProps['id_wikidata'] &&
                     fProps['id_wikidata'] !== 'null' &&
                     null != fProps['id_wikidata'].value
                   ) {
                     id = fProps['id_wikidata'].value;
-                  } else if (
-                    fProps['id_osm'] !== null &&
-                    fProps['id_osm'] !== 'null' &&
-                    null != fProps['id_osm'].value
-                  ) {
+                  } else if (fProps['id_osm'] && fProps['id_osm'] !== 'null' && null != fProps['id_osm'].value) {
                     id = fProps['id_osm'].value;
                   }
                   const dscShort = fProps[`description_short_${lang}`];

--- a/src/app/locations.ts
+++ b/src/app/locations.ts
@@ -15,7 +15,7 @@ import { environment } from '../environments/environment';
 //TODO it would make more sense to just share the typescript constant instead of using json IMO
 import * as locationsJSON from './../assets/locations.json';
 import { defaultCity } from './city/map.service';
-import { Bounds, LngLat } from './types';
+import { BoundingBox, LngLat, uncheckedBoundingBoxToChecked } from './types';
 
 // TODO it would make more sense to move common types to an own library which is consumed by both, datablue and proximap
 // if you change something here, then you need to change it in datablue as well
@@ -23,14 +23,15 @@ export interface Location {
   name: string;
   description: Translated<string>;
   description_more: Translated<string>;
-  bounding_box: BoundingBox;
+  bounding_box: UncheckedBoundingBox;
+  //TODO @ralf.hauser not used as it seems, remove?
   operator_fountain_catalog_qid: string;
   issue_api: IssueApi;
 }
 
 // TODO it would make more sense to move common types to an own library which is consumed by both, datablue and proximap
 // if you change something here, then you need to change it in datablue as well
-export interface BoundingBox {
+export interface UncheckedBoundingBox {
   latMin: number;
   lngMin: number;
   latMax: number;
@@ -65,12 +66,21 @@ export const cities: City[] = Object.keys(locationsCollection).filter(
   city => city !== 'default' && (city !== 'test' || !environment.production)
 ) as City[];
 
-export function getLocationBounds(city: City): Bounds {
-  const boundingBox = locationsCollection[city].bounding_box;
-  return { min: LngLat(boundingBox.lngMin, boundingBox.latMin), max: LngLat(boundingBox.lngMax, boundingBox.latMax) };
+// TODO it would make more sense to move common types to an own library which is consumed by both, datablue and proximap
+// if you change something here, then you need to change it in datablue as well
+export function getCityBoundingBox(city: City): BoundingBox {
+  const uncheckedBoundingBox = locationsCollection[city].bounding_box;
+  return uncheckedBoundingBoxToChecked(uncheckedBoundingBox);
 }
-export const defaultCityLocationBounds = getLocationBounds(defaultCity);
+export const defaultCityBoundingBox = getCityBoundingBox(defaultCity);
 
-export function getCentre(bounds: Bounds): LngLat {
+export function getCentre(bounds: BoundingBox): LngLat {
   return LngLat((bounds.min.lng + bounds.max.lng) / 2.0, (bounds.min.lat + bounds.max.lat) / 2);
 }
+
+// TODO it would make more sense to move common types to an own library which is consumed by both, datablue and proximap
+// if you change something here, then you need to change it in datablue as well
+// 0.05 lat is ~5km
+export const TILE_SIZE = 0.05;
+export const ROUND_FACTOR = 20; // 1 / 0.05;
+export const LNG_LAT_STRING_PRECISION = 2;

--- a/src/app/map/map.component.ts
+++ b/src/app/map/map.component.ts
@@ -17,13 +17,13 @@ import { DataService } from '../data.service';
 import { DirectionsService } from '../directions/directions.service';
 import { FountainService } from '../fountain/fountain.service';
 import { City } from '../locations';
-import { Bounds, Fountain, FountainCollection, LngLat } from '../types';
+import { BoundingBox, Fountain, FountainCollection, LngLat } from '../types';
 import { MapService, MapState } from '../city/map.service';
 import { MapConfig } from './map.config';
 import { UserLocationService } from './user-location.service';
 import _ from 'lodash';
 import { Subject } from 'rxjs';
-import { debounceTime, skip } from 'rxjs/operators';
+import { skip } from 'rxjs/operators';
 
 @Component({
   selector: 'app-map',
@@ -85,12 +85,7 @@ export class MapComponent implements OnInit {
       // this.mapService.city.pipe(filterUndefined()).subscribe(city => this.fitToCityBoundsIfNotSame(city)),
       this.mapService.state.subscribe(state => this.adjustMapToStateChange(state)),
 
-      this.mapLocationChangeSubject
-        .pipe(
-          // don't trigger multiple change events shortly after each other (e.g. when resizing window)
-          debounceTime(100)
-        )
-        .subscribe(_ => this.handleMapLocationChange()),
+      this.mapLocationChangeSubject.subscribe(_ => this.handleMapLocationChange()),
 
       // When directions are loaded, display on map
       this.directionsService.directions.subscribe(data => {
@@ -204,7 +199,7 @@ export class MapComponent implements OnInit {
                 pitch: 0,
                 bearing: 0,
               };
-              this.map.fitBounds([newState.bounds.min, newState.bounds.max], options);
+              this.map.fitBounds([newState.boundingBox.min, newState.boundingBox.max], options);
               this.actOnFirstLoad();
             }
           } catch (e: unknown) {
@@ -239,7 +234,13 @@ export class MapComponent implements OnInit {
     const mapboxBounds = this.map.getBounds();
     const sw = mapboxBounds.getSouthWest();
     const ne = mapboxBounds.getNorthEast();
-    return { bounds: Bounds(sw, ne), location: this.map.getCenter(), city: city, zoom: this.map.getZoom() };
+    return {
+      boundingBox: BoundingBox(sw, ne),
+      isFakeBoundingBox: false,
+      location: this.map.getCenter(),
+      city: city,
+      zoom: this.map.getZoom(),
+    };
   }
 
   private zoomOut(): void {

--- a/src/app/mobile-menu/mobile-menu.component.html
+++ b/src/app/mobile-menu/mobile-menu.component.html
@@ -23,7 +23,7 @@
       <ng-container *ngIf="cityObservable | async; let city">
         <!--   Add city-specific info for https://github.com/water-fountains/proximap/issues/277   -->
         <div
-          *ngIf="locationsCollection !== undefined && city"
+          *ngIf="locationsCollection !== undefined && city && locationsCollection[city].description[lang]"
           [innerHTML]="locationsCollection[city].description[lang]"
         ></div>
         <mat-expansion-panel
@@ -82,7 +82,7 @@
       <app-city-selector class="full-size"></app-city-selector>
       <p>
         {{ 'settings.city_last_scan' | translate }}: {{ last_scan | date: 'long':'':lang }}. <br />
-        {{ 'settings.city_next_scan_info' | translate }} {{ publicSharedConsts?.CACHE_FOR_HRS_i45db }}
+        {{ 'settings.city_next_scan_info' | translate }}
       </p>
       <button class="mat-stroked-button responsive" (click)="refreshCurrentLocationData(); setShowMenu(false)">
         {{ 'settings.reprocess_city' | translate }}

--- a/src/app/mobile-menu/mobile-menu.component.ts
+++ b/src/app/mobile-menu/mobile-menu.component.ts
@@ -6,7 +6,6 @@
  */
 
 import { Component, OnInit } from '@angular/core';
-import _ from 'lodash';
 import { versions } from '../../environments/versions';
 import { LanguageService } from '../core/language.service';
 import { LayoutService } from '../core/layout.service';
@@ -56,7 +55,9 @@ export class MobileMenuComponent implements OnInit {
       // watch for fountains to be loaded to obtain last scan time
       // for https://github.com/water-fountains/proximap/issues/188 1)
       this.dataService.fountainsLoadedSuccess.subscribe(fountains => {
-        this.last_scan = _.get(fountains, ['properties', 'last_scan'], null);
+        if (fountains.last_scan !== undefined) {
+          this.last_scan = fountains.last_scan;
+        }
       })
     );
   }

--- a/src/app/navbar/navbar.component.ts
+++ b/src/app/navbar/navbar.component.ts
@@ -6,7 +6,6 @@
  */
 
 import { Component, OnInit } from '@angular/core';
-import _ from 'lodash';
 import { environment } from '../../environments/environment';
 import { LayoutService } from '../core/layout.service';
 import { SubscriptionService } from '../core/subscription.service';
@@ -48,7 +47,9 @@ export class NavbarComponent implements OnInit {
     // for https://github.com/water-fountains/proximap/issues/188 2)
     this.subscriptionService.registerSubscriptions(
       this.dataService.fountainsLoadedSuccess.subscribe(fountains => {
-        this.last_scan = _.get(fountains, ['properties', 'last_scan'], '');
+        if (fountains.last_scan !== undefined) {
+          this.last_scan = fountains.last_scan;
+        }
       })
     );
   }

--- a/src/app/router/router.component.ts
+++ b/src/app/router/router.component.ts
@@ -67,6 +67,7 @@ export class RouterComponent implements OnInit {
       // Yet, they cannot really change independently and should be consolidated in one state
       combineLatest([this.mapService.state, this.fountainService.fountainSelector])
         .pipe(
+          filter(([state, _]) => !state.isFakeBoundingBox),
           map(
             ([state, selector]) => [state.city, this.toQueryParams(state, selector)] as [City | undefined, QueryParams]
           ),

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -202,7 +202,7 @@
   "settings": {
     "city": "Stadt ändern",
     "city_last_scan": "Letzte Aktualisierung am",
-    "city_next_scan_info": "Aktualisierungen finden automatisch statt - alle (Stunden): ",
+    "city_next_scan_info": "Aktualisierungen finden automatisch periodisch statt.",
     "lang": "Sprache ändern",
     "reprocess_city": "alle Brunnen aktualisieren"
   },

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -200,7 +200,7 @@
   "settings": {
     "city": "Change city",
     "city_last_scan": "Last processing",
-    "city_next_scan_info": "Data is reprocessed every (hours): ",
+    "city_next_scan_info": "Data is periodically reprocessed automatically.",
     "lang": "Change language",
     "reprocess_city": "reprocess all fountains now"
   },

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -201,7 +201,7 @@
   "settings": {
     "city": "Changer de lieu",
     "city_last_scan": "Dernier scan le",
-    "city_next_scan_info": "Un scan est effectué automatiquement toutes les (heures) ",
+    "city_next_scan_info": "Un scan est effectué periodiquement.",
     "lang": "Changer la langue",
     "reprocess_city": "re-scanner toute la ville"
   },

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -200,7 +200,7 @@
   "settings": {
     "city": "Cambia la città",
     "city_last_scan": "Ultima elaborazione",
-    "city_next_scan_info": "I dati sono elaborati ogni (ore): ",
+    "city_next_scan_info": "I dati sono periodicamente elaborati.",
     "lang": "Cambia la lingua",
     "reprocess_city": "Elabora nuovamente tutte le fontane ora"
   },

--- a/src/assets/i18n/tr.json
+++ b/src/assets/i18n/tr.json
@@ -196,7 +196,7 @@
   "settings": {
     "city": "Şehir değiştir",
     "city_last_scan": "son işleme",
-    "city_next_scan_info": "Veri her iki saatte bir yeniden işlenir.",
+    "city_next_scan_info": "Veriler periyodik olarak otomatik olarak işlenir.",
     "lang": "Dil değiştir",
     "reprocess_city": "Tüm çeşmeleri şimdi yeniden işle."
   },


### PR DESCRIPTION
fountains and processing errors

moreover:
- send loc for byId
- fix selectFountainByFeature for osm (partially #506)
- send lat,lng in tile precision so that http caching can kick in
  (because of same URL and same etag)
- add isFakeBoundingBox to MapState in order to filter it out
  in routing and fetching from server
- adopted FountainCollection according to datablue, lastScan is now a
  property